### PR TITLE
Add ignores for build artifacts and logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Dependencies
+node_modules/
+
+# Logs
+*.log
+
+# Build output
+/dist/
+**/dist/
+.next/
+**/.next/
+
+# Temporary files
+*.tmp
+*.temp
+*~
+*.swp
+.DS_Store


### PR DESCRIPTION
## Summary
- update `.gitignore` to exclude node modules, logs, build output and temp files

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68757e5731d883229444e3a317e44523