### PR TITLE
Configure fonts and base typography

### DIFF
--- a/apps/frontend/src/pages/_document.tsx
+++ b/apps/frontend/src/pages/_document.tsx
@@ -1,0 +1,17 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+export default function Document() {
+  return (
+    <Html>
+      <Head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Poppins:wght@300;400;500;600;700&family=Cairo:wght@300;400;500;600;700&family=Tajawal:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/apps/frontend/src/styles/globals.css
+++ b/apps/frontend/src/styles/globals.css
@@ -2,7 +2,16 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  body {
+    @apply font-sans;
+  }
+  .rtl {
+    @apply font-arabic;
+    direction: rtl;
+  }
+}
+
 html {
   scroll-behavior: smooth;
 }
-.rtl { direction: rtl; }

--- a/apps/frontend/tailwind.config.js
+++ b/apps/frontend/tailwind.config.js
@@ -5,7 +5,12 @@ module.exports = {
   ],
   darkMode: 'class',
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['Poppins', 'Inter', 'sans-serif'],
+        arabic: ['Tajawal', 'Cairo', 'sans-serif'],
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- add custom `_document.tsx` with Google Fonts links
- define sans and arabic font families in Tailwind config
- apply base font classes in `globals.css`

## Testing
- `npm test`
- `npm --workspaces --if-present test`
- `npm --workspace apps/frontend run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687643e731488322b6c2e0c39b39e7e7