### PR TITLE
Add tailwindcss-rtl plugin to frontend

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -26,6 +26,7 @@
     "eslint-config-next": "^14.2.3",
     "postcss": "^8.4.24",
     "tailwindcss": "^3.3.5",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "tailwindcss-rtl": "^1.2.0"
   }
 }

--- a/apps/frontend/src/styles/globals.css
+++ b/apps/frontend/src/styles/globals.css
@@ -5,4 +5,3 @@
 html {
   scroll-behavior: smooth;
 }
-.rtl { direction: rtl; }

--- a/apps/frontend/tailwind.config.js
+++ b/apps/frontend/tailwind.config.js
@@ -7,5 +7,7 @@ module.exports = {
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [
+    require('tailwindcss-rtl')
+  ],
 }


### PR DESCRIPTION
## Summary
- add `tailwindcss-rtl` as a devDependency
- use `tailwindcss-rtl` plugin in `tailwind.config.js`
- remove obsolete `.rtl` rule from global styles

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687643fc2bd08322b34a729bc8476d38