### PR TITLE
Add AppLayout for RTL support

### DIFF
--- a/apps/frontend/src/components/AppLayout.tsx
+++ b/apps/frontend/src/components/AppLayout.tsx
@@ -1,0 +1,20 @@
+import { ReactNode, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface AppLayoutProps {
+  children: ReactNode;
+}
+
+export default function AppLayout({ children }: AppLayoutProps) {
+  const { i18n } = useTranslation();
+
+  useEffect(() => {
+    document.documentElement.dir = i18n.language === 'ar' ? 'rtl' : 'ltr';
+  }, [i18n.language]);
+
+  return (
+    <div className={i18n.language === 'ar' ? 'font-arabic' : 'font-sans'}>
+      {children}
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/_app.tsx
+++ b/apps/frontend/src/pages/_app.tsx
@@ -4,10 +4,15 @@ import 'aos/dist/aos.css';
 import { useEffect } from 'react';
 import AOS from 'aos';
 import '../i18n';
+import AppLayout from '../components/AppLayout';
 
 export default function App({ Component, pageProps }: AppProps) {
   useEffect(() => {
     AOS.init({ once: true });
   }, []);
-  return <Component {...pageProps} />;
+  return (
+    <AppLayout>
+      <Component {...pageProps} />
+    </AppLayout>
+  );
 }


### PR DESCRIPTION
## Summary
- create a new `AppLayout` component that sets `dir` based on locale
- wrap all pages with `AppLayout` in Next.js `_app.tsx`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687643fd6ce8832297b61a82924d680b