### PR TITLE
Update RTL handling

### DIFF
--- a/apps/frontend/src/pages/index.tsx
+++ b/apps/frontend/src/pages/index.tsx
@@ -9,7 +9,7 @@ export default function Home() {
   const [lang, setLang] = useState(i18n.language || 'fr');
 
   return (
-    <div className={lang === 'ar' ? 'rtl' : ''}>
+    <div dir={lang === 'ar' ? 'rtl' : 'ltr'}>
       <Head>
         <title>{t('pageTitle')}</title>
         <meta name="description" content={t('pageDescription')} />
@@ -49,7 +49,7 @@ export default function Home() {
               <option value="en">EN</option>
               <option value="ar">AR</option>
             </select>
-            <button className="text-sm px-3 py-1 text-left">{t('nav.login')}</button>
+            <button className="text-sm px-3 py-1 text-left rtl:text-right">{t('nav.login')}</button>
             <button className="bg-indigo-600 text-white px-3 py-1 rounded w-max">{t('nav.signup')}</button>
           </div>
         )}

--- a/apps/frontend/src/styles/globals.css
+++ b/apps/frontend/src/styles/globals.css
@@ -5,4 +5,3 @@
 html {
   scroll-behavior: smooth;
 }
-.rtl { direction: rtl; }


### PR DESCRIPTION
## Summary
- drop `rtl` wrapper div and rely on `dir` attribute
- add RTL utility usage for login button
- clean up unused style

## Testing
- `npm test`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687643fea14083229b37fa8088bc5904