### PR TITLE
Refactor frontend homepage sections

### DIFF
--- a/apps/frontend/src/components/ContactForm.tsx
+++ b/apps/frontend/src/components/ContactForm.tsx
@@ -1,0 +1,16 @@
+import { useTranslation } from 'react-i18next';
+
+export default function ContactForm() {
+  const { t } = useTranslation();
+  return (
+    <section id="contact" className="max-w-4xl mx-auto px-4" data-aos="fade-up">
+      <h2 className="text-2xl font-bold text-center mb-8">{t('contact.title')}</h2>
+      <form className="grid gap-4">
+        <input type="text" placeholder={t('contact.name')} className="border p-2 rounded" required />
+        <input type="email" placeholder={t('contact.email')} className="border p-2 rounded" required />
+        <textarea placeholder={t('contact.message')} className="border p-2 rounded" rows={4} required></textarea>
+        <button type="submit" className="bg-indigo-600 text-white px-4 py-2 rounded w-max mx-auto">{t('contact.submit')}</button>
+      </form>
+    </section>
+  );
+}

--- a/apps/frontend/src/components/Disciplines.tsx
+++ b/apps/frontend/src/components/Disciplines.tsx
@@ -1,0 +1,19 @@
+import { useTranslation } from 'react-i18next';
+
+export default function Disciplines() {
+  const { t } = useTranslation();
+  return (
+    <section className="max-w-6xl mx-auto px-4" data-aos="fade-up">
+      <h2 className="text-2xl font-bold text-center mb-8">{t('disciplines.title')}</h2>
+      <div className="grid grid-cols-3 sm:grid-cols-6 gap-6 text-center text-sm">
+        <div className="flex flex-col items-center"><span className="text-3xl">∑</span>{t('disciplines.math')}</div>
+        <div className="flex flex-col items-center"><span className="text-3xl">⚛</span>{t('disciplines.science')}</div>
+        <div className="flex flex-col items-center"><span className="text-3xl">🌐</span>{t('disciplines.languages')}</div>
+        <div className="flex flex-col items-center"><span className="text-3xl">🏰</span>{t('disciplines.history')}</div>
+        <div className="flex flex-col items-center"><span className="text-3xl">💻</span>{t('disciplines.computer')}</div>
+        <div className="flex flex-col items-center"><span className="text-3xl">🎨</span>{t('disciplines.arts')}</div>
+      </div>
+      <p className="text-center mt-6 text-gray-600">{t('disciplines.tagline')}</p>
+    </section>
+  );
+}

--- a/apps/frontend/src/components/Features.tsx
+++ b/apps/frontend/src/components/Features.tsx
@@ -1,0 +1,42 @@
+import { useTranslation } from 'react-i18next';
+
+export default function Features() {
+  const { t } = useTranslation();
+  return (
+    <section className="bg-gray-50 py-16" id="features" data-aos="fade-up">
+      <h2 className="text-2xl font-bold text-center mb-8">{t('features.title')}</h2>
+      <div className="max-w-5xl mx-auto px-4">
+        <div className="grid md:grid-cols-3 gap-8">
+          <div>
+            <h3 className="font-semibold text-lg mb-4">{t('features.schools.title')}</h3>
+            <ul className="space-y-2 list-disc list-inside">
+              <li>{t('features.schools.item1')}</li>
+              <li>{t('features.schools.item2')}</li>
+              <li>{t('features.schools.item3')}</li>
+              <li>{t('features.schools.item4')}</li>
+              <li>{t('features.schools.item5')}</li>
+            </ul>
+          </div>
+          <div>
+            <h3 className="font-semibold text-lg mb-4">{t('features.teachers.title')}</h3>
+            <ul className="space-y-2 list-disc list-inside">
+              <li>{t('features.teachers.item1')}</li>
+              <li>{t('features.teachers.item2')}</li>
+              <li>{t('features.teachers.item3')}</li>
+              <li>{t('features.teachers.item4')}</li>
+            </ul>
+          </div>
+          <div>
+            <h3 className="font-semibold text-lg mb-4">{t('features.learners.title')}</h3>
+            <ul className="space-y-2 list-disc list-inside">
+              <li>{t('features.learners.item1')}</li>
+              <li>{t('features.learners.item2')}</li>
+              <li>{t('features.learners.item3')}</li>
+              <li>{t('features.learners.item4')}</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/src/components/Footer.tsx
+++ b/apps/frontend/src/components/Footer.tsx
@@ -1,0 +1,40 @@
+import { useTranslation } from 'react-i18next';
+
+export default function Footer() {
+  const { t } = useTranslation();
+  return (
+    <footer className="bg-gray-900 text-gray-300 mt-24" data-aos="fade-up">
+      <div className="max-w-6xl mx-auto py-12 px-4 grid md:grid-cols-4 gap-8">
+        <div>
+          <h3 className="font-semibold mb-2">{t('footer.legal.title')}</h3>
+          <ul className="space-y-1 text-sm">
+            <li><a href="#" className="hover:underline">{t('footer.legal.terms')}</a></li>
+            <li><a href="#" className="hover:underline">{t('footer.legal.privacy')}</a></li>
+          </ul>
+        </div>
+        <div>
+          <h3 className="font-semibold mb-2">{t('footer.links.title')}</h3>
+          <ul className="space-y-1 text-sm">
+            <li><a href="#" className="hover:underline">{t('footer.links.support')}</a></li>
+            <li><a href="#" className="hover:underline">{t('footer.links.docs')}</a></li>
+            <li><a href="#" className="hover:underline">{t('footer.links.blog')}</a></li>
+          </ul>
+        </div>
+        <div>
+          <h3 className="font-semibold mb-2">{t('footer.social.title')}</h3>
+          <ul className="space-y-1 text-sm">
+            <li><a href="#" className="hover:underline">{t('footer.social.twitter')}</a></li>
+            <li><a href="#" className="hover:underline">{t('footer.social.linkedin')}</a></li>
+            <li><a href="#" className="hover:underline">{t('footer.social.facebook')}</a></li>
+          </ul>
+        </div>
+        <div>
+          <h3 className="font-semibold mb-2">{t('footer.contact.title')}</h3>
+          <p className="text-sm">{t('footer.contact.email')}</p>
+          <p className="text-sm">{t('footer.contact.phone')}</p>
+        </div>
+      </div>
+      <p className="text-center text-xs pb-4">{t('footer.copyright')}</p>
+    </footer>
+  );
+}

--- a/apps/frontend/src/components/Hero.tsx
+++ b/apps/frontend/src/components/Hero.tsx
@@ -1,0 +1,16 @@
+import { useTranslation } from 'react-i18next';
+
+export default function Hero() {
+  const { t } = useTranslation();
+  return (
+    <section className="text-center py-20 bg-gray-50" data-aos="fade-up">
+      <img src="/illustration.svg" alt={t('hero.imageAlt')} className="mx-auto mb-8 max-w-md" />
+      <h1 className="text-3xl sm:text-5xl font-bold mb-6 max-w-4xl mx-auto">{t('hero.title')}</h1>
+      <p className="max-w-3xl mx-auto mb-8 text-lg text-gray-600">{t('hero.subtitle')}</p>
+      <div className="flex justify-center gap-4">
+        <a href="#" className="bg-indigo-600 text-white px-6 py-3 rounded">{t('hero.ctaPrimary')}</a>
+        <a href="#" className="bg-gray-200 text-gray-900 px-6 py-3 rounded">{t('hero.ctaSecondary')}</a>
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/src/components/Pricing.tsx
+++ b/apps/frontend/src/components/Pricing.tsx
@@ -1,0 +1,41 @@
+import { useTranslation } from 'react-i18next';
+
+export default function Pricing() {
+  const { t } = useTranslation();
+  return (
+    <section className="bg-gray-50 py-16" id="pricing" data-aos="fade-up">
+      <h2 className="text-2xl font-bold text-center mb-8">{t('pricing.title')}</h2>
+      <div className="max-w-6xl mx-auto grid md:grid-cols-3 gap-6 px-4">
+        <div className="border rounded-lg p-6 text-center flex flex-col">
+          <h3 className="font-semibold mb-2">{t('pricing.free.label')}</h3>
+          <p className="mb-4">{t('pricing.free.desc')}</p>
+          <p className="text-3xl font-bold mb-6">{t('pricing.free.price')}</p>
+          <ul className="flex-1 space-y-1">
+            <li>{t('pricing.free.feature1')}</li>
+          </ul>
+          <button className="mt-6 bg-indigo-600 text-white px-4 py-2 rounded">{t('pricing.free.cta')}</button>
+        </div>
+        <div className="border rounded-lg p-6 text-center flex flex-col">
+          <h3 className="font-semibold mb-2">{t('pricing.starter.label')}</h3>
+          <p className="mb-4">{t('pricing.starter.desc')}</p>
+          <p className="text-3xl font-bold mb-6">{t('pricing.starter.price')}</p>
+          <ul className="flex-1 space-y-1">
+            <li>{t('pricing.starter.feature1')}</li>
+            <li>{t('pricing.starter.feature2')}</li>
+          </ul>
+          <button className="mt-6 bg-indigo-600 text-white px-4 py-2 rounded">{t('pricing.starter.cta')}</button>
+        </div>
+        <div className="border rounded-lg p-6 text-center flex flex-col">
+          <h3 className="font-semibold mb-2">{t('pricing.pro.label')}</h3>
+          <p className="mb-4">{t('pricing.pro.desc')}</p>
+          <p className="text-3xl font-bold mb-6">{t('pricing.pro.price')}</p>
+          <ul className="flex-1 space-y-1">
+            <li>{t('pricing.pro.feature1')}</li>
+            <li>{t('pricing.pro.feature2')}</li>
+          </ul>
+          <button className="mt-6 bg-indigo-600 text-white px-4 py-2 rounded">{t('pricing.pro.cta')}</button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/src/components/Testimonials.tsx
+++ b/apps/frontend/src/components/Testimonials.tsx
@@ -1,0 +1,24 @@
+import { useTranslation } from 'react-i18next';
+
+export default function Testimonials() {
+  const { t } = useTranslation();
+  return (
+    <section className="max-w-6xl mx-auto px-4" data-aos="fade-up">
+      <h2 className="text-2xl font-bold text-center mb-8">{t('testimonials.title')}</h2>
+      <div className="grid md:grid-cols-3 gap-6">
+        <div className="border rounded-lg p-6 shadow-sm">
+          <p className="mb-2 italic">{t('testimonials.item1.quote')}</p>
+          <p className="font-semibold">{t('testimonials.item1.author')}</p>
+        </div>
+        <div className="border rounded-lg p-6 shadow-sm">
+          <p className="mb-2 italic">{t('testimonials.item2.quote')}</p>
+          <p className="font-semibold">{t('testimonials.item2.author')}</p>
+        </div>
+        <div className="border rounded-lg p-6 shadow-sm">
+          <p className="mb-2 italic">{t('testimonials.item3.quote')}</p>
+          <p className="font-semibold">{t('testimonials.item3.author')}</p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/src/components/Who.tsx
+++ b/apps/frontend/src/components/Who.tsx
@@ -1,0 +1,28 @@
+import { AcademicCapIcon, UserGroupIcon, BuildingLibraryIcon } from '@heroicons/react/24/outline';
+import { useTranslation } from 'react-i18next';
+
+export default function Who() {
+  const { t } = useTranslation();
+  return (
+    <section className="max-w-6xl mx-auto px-4" data-aos="fade-up" id="about">
+      <h2 className="text-2xl font-bold text-center mb-8">{t('who.title')}</h2>
+      <div className="grid md:grid-cols-3 gap-6">
+        <div className="p-6 border rounded-lg text-center flex flex-col items-center">
+          <BuildingLibraryIcon className="h-10 w-10 text-indigo-600 mb-4" />
+          <h3 className="font-semibold mb-2">{t('who.schools.title')}</h3>
+          <p>{t('who.schools.desc')}</p>
+        </div>
+        <div className="p-6 border rounded-lg text-center flex flex-col items-center">
+          <UserGroupIcon className="h-10 w-10 text-indigo-600 mb-4" />
+          <h3 className="font-semibold mb-2">{t('who.teachers.title')}</h3>
+          <p>{t('who.teachers.desc')}</p>
+        </div>
+        <div className="p-6 border rounded-lg text-center flex flex-col items-center">
+          <AcademicCapIcon className="h-10 w-10 text-indigo-600 mb-4" />
+          <h3 className="font-semibold mb-2">{t('who.learners.title')}</h3>
+          <p>{t('who.learners.desc')}</p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/src/components/Why.tsx
+++ b/apps/frontend/src/components/Why.tsx
@@ -1,0 +1,33 @@
+import { CheckCircleIcon } from '@heroicons/react/24/outline';
+import { useTranslation } from 'react-i18next';
+
+export default function Why() {
+  const { t } = useTranslation();
+  return (
+    <section className="bg-gray-50 py-16" data-aos="fade-up">
+      <h2 className="text-2xl font-bold text-center mb-8">{t('why.title')}</h2>
+      <div className="max-w-5xl mx-auto grid md:grid-cols-4 gap-8 px-4 text-center">
+        <div>
+          <CheckCircleIcon className="h-8 w-8 text-indigo-600 mx-auto mb-2" />
+          <h3 className="font-semibold mb-2">{t('why.flexibility.title')}</h3>
+          <p>{t('why.flexibility.desc')}</p>
+        </div>
+        <div>
+          <CheckCircleIcon className="h-8 w-8 text-indigo-600 mx-auto mb-2" />
+          <h3 className="font-semibold mb-2">{t('why.ease.title')}</h3>
+          <p>{t('why.ease.desc')}</p>
+        </div>
+        <div>
+          <CheckCircleIcon className="h-8 w-8 text-indigo-600 mx-auto mb-2" />
+          <h3 className="font-semibold mb-2">{t('why.security.title')}</h3>
+          <p>{t('why.security.desc')}</p>
+        </div>
+        <div>
+          <CheckCircleIcon className="h-8 w-8 text-indigo-600 mx-auto mb-2" />
+          <h3 className="font-semibold mb-2">{t('why.scalability.title')}</h3>
+          <p>{t('why.scalability.desc')}</p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/src/pages/index.tsx
+++ b/apps/frontend/src/pages/index.tsx
@@ -1,7 +1,16 @@
 import Head from 'next/head';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Bars3Icon, XMarkIcon, AcademicCapIcon, UserGroupIcon, BuildingLibraryIcon, CheckCircleIcon } from '@heroicons/react/24/outline';
+import { Bars3Icon, XMarkIcon, AcademicCapIcon } from '@heroicons/react/24/outline';
+import Hero from '../components/Hero';
+import Who from '../components/Who';
+import Features from '../components/Features';
+import Disciplines from '../components/Disciplines';
+import Why from '../components/Why';
+import Testimonials from '../components/Testimonials';
+import Pricing from '../components/Pricing';
+import ContactForm from '../components/ContactForm';
+import Footer from '../components/Footer';
 
 export default function Home() {
   const { t, i18n } = useTranslation();
@@ -56,217 +65,17 @@ export default function Home() {
       </header>
 
       <main className="pt-20 space-y-24">
-        {/* Hero Section */}
-        <section className="text-center py-20 bg-gray-50" data-aos="fade-up">
-          <img src="/illustration.svg" alt={t('hero.imageAlt')} className="mx-auto mb-8 max-w-md" />
-          <h1 className="text-3xl sm:text-5xl font-bold mb-6 max-w-4xl mx-auto">{t('hero.title')}</h1>
-          <p className="max-w-3xl mx-auto mb-8 text-lg text-gray-600">{t('hero.subtitle')}</p>
-          <div className="flex justify-center gap-4">
-            <a href="#" className="bg-indigo-600 text-white px-6 py-3 rounded">{t('hero.ctaPrimary')}</a>
-            <a href="#" className="bg-gray-200 text-gray-900 px-6 py-3 rounded">{t('hero.ctaSecondary')}</a>
-          </div>
-        </section>
-
-        {/* Who Section */}
-        <section className="max-w-6xl mx-auto px-4" data-aos="fade-up" id="about">
-          <h2 className="text-2xl font-bold text-center mb-8">{t('who.title')}</h2>
-          <div className="grid md:grid-cols-3 gap-6">
-            <div className="p-6 border rounded-lg text-center flex flex-col items-center">
-              <BuildingLibraryIcon className="h-10 w-10 text-indigo-600 mb-4" />
-              <h3 className="font-semibold mb-2">{t('who.schools.title')}</h3>
-              <p>{t('who.schools.desc')}</p>
-            </div>
-            <div className="p-6 border rounded-lg text-center flex flex-col items-center">
-              <UserGroupIcon className="h-10 w-10 text-indigo-600 mb-4" />
-              <h3 className="font-semibold mb-2">{t('who.teachers.title')}</h3>
-              <p>{t('who.teachers.desc')}</p>
-            </div>
-            <div className="p-6 border rounded-lg text-center flex flex-col items-center">
-              <AcademicCapIcon className="h-10 w-10 text-indigo-600 mb-4" />
-              <h3 className="font-semibold mb-2">{t('who.learners.title')}</h3>
-              <p>{t('who.learners.desc')}</p>
-            </div>
-          </div>
-        </section>
-
-        {/* Features Section */}
-        <section className="bg-gray-50 py-16" id="features" data-aos="fade-up">
-          <h2 className="text-2xl font-bold text-center mb-8">{t('features.title')}</h2>
-          <div className="max-w-5xl mx-auto px-4">
-            <div className="grid md:grid-cols-3 gap-8">
-              <div>
-                <h3 className="font-semibold text-lg mb-4">{t('features.schools.title')}</h3>
-                <ul className="space-y-2 list-disc list-inside">
-                  <li>{t('features.schools.item1')}</li>
-                  <li>{t('features.schools.item2')}</li>
-                  <li>{t('features.schools.item3')}</li>
-                  <li>{t('features.schools.item4')}</li>
-                  <li>{t('features.schools.item5')}</li>
-                </ul>
-              </div>
-              <div>
-                <h3 className="font-semibold text-lg mb-4">{t('features.teachers.title')}</h3>
-                <ul className="space-y-2 list-disc list-inside">
-                  <li>{t('features.teachers.item1')}</li>
-                  <li>{t('features.teachers.item2')}</li>
-                  <li>{t('features.teachers.item3')}</li>
-                  <li>{t('features.teachers.item4')}</li>
-                </ul>
-              </div>
-              <div>
-                <h3 className="font-semibold text-lg mb-4">{t('features.learners.title')}</h3>
-                <ul className="space-y-2 list-disc list-inside">
-                  <li>{t('features.learners.item1')}</li>
-                  <li>{t('features.learners.item2')}</li>
-                  <li>{t('features.learners.item3')}</li>
-                  <li>{t('features.learners.item4')}</li>
-                </ul>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        {/* Disciplines Section */}
-        <section className="max-w-6xl mx-auto px-4" data-aos="fade-up">
-          <h2 className="text-2xl font-bold text-center mb-8">{t('disciplines.title')}</h2>
-          <div className="grid grid-cols-3 sm:grid-cols-6 gap-6 text-center text-sm">
-            <div className="flex flex-col items-center"><span className="text-3xl">∑</span>{t('disciplines.math')}</div>
-            <div className="flex flex-col items-center"><span className="text-3xl">⚛</span>{t('disciplines.science')}</div>
-            <div className="flex flex-col items-center"><span className="text-3xl">🌐</span>{t('disciplines.languages')}</div>
-            <div className="flex flex-col items-center"><span className="text-3xl">🏰</span>{t('disciplines.history')}</div>
-            <div className="flex flex-col items-center"><span className="text-3xl">💻</span>{t('disciplines.computer')}</div>
-            <div className="flex flex-col items-center"><span className="text-3xl">🎨</span>{t('disciplines.arts')}</div>
-          </div>
-          <p className="text-center mt-6 text-gray-600">{t('disciplines.tagline')}</p>
-        </section>
-
-        {/* Why Section */}
-        <section className="bg-gray-50 py-16" data-aos="fade-up">
-          <h2 className="text-2xl font-bold text-center mb-8">{t('why.title')}</h2>
-          <div className="max-w-5xl mx-auto grid md:grid-cols-4 gap-8 px-4 text-center">
-            <div>
-              <CheckCircleIcon className="h-8 w-8 text-indigo-600 mx-auto mb-2" />
-              <h3 className="font-semibold mb-2">{t('why.flexibility.title')}</h3>
-              <p>{t('why.flexibility.desc')}</p>
-            </div>
-            <div>
-              <CheckCircleIcon className="h-8 w-8 text-indigo-600 mx-auto mb-2" />
-              <h3 className="font-semibold mb-2">{t('why.ease.title')}</h3>
-              <p>{t('why.ease.desc')}</p>
-            </div>
-            <div>
-              <CheckCircleIcon className="h-8 w-8 text-indigo-600 mx-auto mb-2" />
-              <h3 className="font-semibold mb-2">{t('why.security.title')}</h3>
-              <p>{t('why.security.desc')}</p>
-            </div>
-            <div>
-              <CheckCircleIcon className="h-8 w-8 text-indigo-600 mx-auto mb-2" />
-              <h3 className="font-semibold mb-2">{t('why.scalability.title')}</h3>
-              <p>{t('why.scalability.desc')}</p>
-            </div>
-          </div>
-        </section>
-
-        {/* Testimonials */}
-        <section className="max-w-6xl mx-auto px-4" data-aos="fade-up">
-          <h2 className="text-2xl font-bold text-center mb-8">{t('testimonials.title')}</h2>
-          <div className="grid md:grid-cols-3 gap-6">
-            <div className="border rounded-lg p-6 shadow-sm">
-              <p className="mb-2 italic">{t('testimonials.item1.quote')}</p>
-              <p className="font-semibold">{t('testimonials.item1.author')}</p>
-            </div>
-            <div className="border rounded-lg p-6 shadow-sm">
-              <p className="mb-2 italic">{t('testimonials.item2.quote')}</p>
-              <p className="font-semibold">{t('testimonials.item2.author')}</p>
-            </div>
-            <div className="border rounded-lg p-6 shadow-sm">
-              <p className="mb-2 italic">{t('testimonials.item3.quote')}</p>
-              <p className="font-semibold">{t('testimonials.item3.author')}</p>
-            </div>
-          </div>
-        </section>
-
-        {/* Pricing */}
-        <section className="bg-gray-50 py-16" id="pricing" data-aos="fade-up">
-          <h2 className="text-2xl font-bold text-center mb-8">{t('pricing.title')}</h2>
-          <div className="max-w-6xl mx-auto grid md:grid-cols-3 gap-6 px-4">
-            <div className="border rounded-lg p-6 text-center flex flex-col">
-              <h3 className="font-semibold mb-2">{t('pricing.free.label')}</h3>
-              <p className="mb-4">{t('pricing.free.desc')}</p>
-              <p className="text-3xl font-bold mb-6">{t('pricing.free.price')}</p>
-              <ul className="flex-1 space-y-1">
-                <li>{t('pricing.free.feature1')}</li>
-              </ul>
-              <button className="mt-6 bg-indigo-600 text-white px-4 py-2 rounded">{t('pricing.free.cta')}</button>
-            </div>
-            <div className="border rounded-lg p-6 text-center flex flex-col">
-              <h3 className="font-semibold mb-2">{t('pricing.starter.label')}</h3>
-              <p className="mb-4">{t('pricing.starter.desc')}</p>
-              <p className="text-3xl font-bold mb-6">{t('pricing.starter.price')}</p>
-              <ul className="flex-1 space-y-1">
-                <li>{t('pricing.starter.feature1')}</li>
-                <li>{t('pricing.starter.feature2')}</li>
-              </ul>
-              <button className="mt-6 bg-indigo-600 text-white px-4 py-2 rounded">{t('pricing.starter.cta')}</button>
-            </div>
-            <div className="border rounded-lg p-6 text-center flex flex-col">
-              <h3 className="font-semibold mb-2">{t('pricing.pro.label')}</h3>
-              <p className="mb-4">{t('pricing.pro.desc')}</p>
-              <p className="text-3xl font-bold mb-6">{t('pricing.pro.price')}</p>
-              <ul className="flex-1 space-y-1">
-                <li>{t('pricing.pro.feature1')}</li>
-                <li>{t('pricing.pro.feature2')}</li>
-              </ul>
-              <button className="mt-6 bg-indigo-600 text-white px-4 py-2 rounded">{t('pricing.pro.cta')}</button>
-            </div>
-          </div>
-        </section>
-
-        {/* Contact section placeholder */}
-        <section id="contact" className="max-w-4xl mx-auto px-4" data-aos="fade-up">
-          <h2 className="text-2xl font-bold text-center mb-8">{t('contact.title')}</h2>
-          <form className="grid gap-4">
-            <input type="text" placeholder={t('contact.name')} className="border p-2 rounded" required />
-            <input type="email" placeholder={t('contact.email')} className="border p-2 rounded" required />
-            <textarea placeholder={t('contact.message')} className="border p-2 rounded" rows={4} required></textarea>
-            <button type="submit" className="bg-indigo-600 text-white px-4 py-2 rounded w-max mx-auto">{t('contact.submit')}</button>
-          </form>
-        </section>
+        <Hero />
+        <Who />
+        <Features />
+        <Disciplines />
+        <Why />
+        <Testimonials />
+        <Pricing />
+        <ContactForm />
       </main>
 
-      <footer className="bg-gray-900 text-gray-300 mt-24" data-aos="fade-up">
-        <div className="max-w-6xl mx-auto py-12 px-4 grid md:grid-cols-4 gap-8">
-          <div>
-            <h3 className="font-semibold mb-2">{t('footer.legal.title')}</h3>
-            <ul className="space-y-1 text-sm">
-              <li><a href="#" className="hover:underline">{t('footer.legal.terms')}</a></li>
-              <li><a href="#" className="hover:underline">{t('footer.legal.privacy')}</a></li>
-            </ul>
-          </div>
-          <div>
-            <h3 className="font-semibold mb-2">{t('footer.links.title')}</h3>
-            <ul className="space-y-1 text-sm">
-              <li><a href="#" className="hover:underline">{t('footer.links.support')}</a></li>
-              <li><a href="#" className="hover:underline">{t('footer.links.docs')}</a></li>
-              <li><a href="#" className="hover:underline">{t('footer.links.blog')}</a></li>
-            </ul>
-          </div>
-          <div>
-            <h3 className="font-semibold mb-2">{t('footer.social.title')}</h3>
-            <ul className="space-y-1 text-sm">
-              <li><a href="#" className="hover:underline">{t('footer.social.twitter')}</a></li>
-              <li><a href="#" className="hover:underline">{t('footer.social.linkedin')}</a></li>
-              <li><a href="#" className="hover:underline">{t('footer.social.facebook')}</a></li>
-            </ul>
-          </div>
-          <div>
-            <h3 className="font-semibold mb-2">{t('footer.contact.title')}</h3>
-            <p className="text-sm">{t('footer.contact.email')}</p>
-            <p className="text-sm">{t('footer.contact.phone')}</p>
-          </div>
-        </div>
-        <p className="text-center text-xs pb-4">{t('footer.copyright')}</p>
-      </footer>
+      <Footer />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- split the homepage into reusable components
- add Hero, Who, Features, Disciplines, Why, Testimonials, Pricing, ContactForm and Footer
- use those components in `pages/index.tsx`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687658bd9184832288adde62237b787b