### PR TITLE
Add Jest and sample tests to frontend

### DIFF
--- a/apps/frontend/jest.config.ts
+++ b/apps/frontend/jest.config.ts
@@ -1,0 +1,17 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1'
+  },
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.jest.json'
+    }
+  }
+};
+
+export default config;

--- a/apps/frontend/jest.setup.ts
+++ b/apps/frontend/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@heroicons/react": "^2.1.1",
@@ -27,6 +28,12 @@
     "postcss": "^8.4.24",
     "tailwindcss": "^3.4.17",
     "tailwindcss-rtl": "^0.9.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.1.4",
+    "@testing-library/user-event": "^14.4.3",
+    "@types/jest": "^29.5.11",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1"
   }
 }

--- a/apps/frontend/src/components/Hero.tsx
+++ b/apps/frontend/src/components/Hero.tsx
@@ -1,0 +1,11 @@
+import { useTranslation } from 'react-i18next';
+
+export default function Hero() {
+  const { t } = useTranslation();
+  return (
+    <section>
+      <h1>{t('hero.title')}</h1>
+      <p>{t('hero.subtitle')}</p>
+    </section>
+  );
+}

--- a/apps/frontend/tests/Hero.test.tsx
+++ b/apps/frontend/tests/Hero.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import Hero from '../src/components/Hero';
+import i18n from '../src/i18n';
+import en from '../src/locales/en/translation.json';
+import fr from '../src/locales/fr/translation.json';
+
+describe('Hero component', () => {
+  it('renders English translation', async () => {
+    await i18n.changeLanguage('en');
+    render(<Hero />);
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(en.hero.title);
+    expect(screen.getByText(en.hero.subtitle)).toBeInTheDocument();
+  });
+
+  it('renders French translation', async () => {
+    await i18n.changeLanguage('fr');
+    render(<Hero />);
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(fr.hero.title);
+    expect(screen.getByText(fr.hero.subtitle)).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/tsconfig.jest.json
+++ b/apps/frontend/tsconfig.jest.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "jsx": "react-jsx"
+  }
+}


### PR DESCRIPTION
## Summary
- configure Jest + Testing Library for `apps/frontend`
- add Hero component
- create Hero tests demonstrating language switching

## Testing
- `npm test --workspace frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876590227f88322a05a1b3405e12d62