### PR TITLE
Add animated background

### DIFF
--- a/apps/frontend/src/components/AppLayout.tsx
+++ b/apps/frontend/src/components/AppLayout.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import Background from './Background';
 
 interface AppLayoutProps {
   children: ReactNode;
@@ -14,6 +15,7 @@ export default function AppLayout({ children }: AppLayoutProps) {
 
   return (
     <div className={i18n.language === 'ar' ? 'font-arabic' : 'font-sans'}>
+      <Background />
       {children}
     </div>
   );

--- a/apps/frontend/src/components/Background.tsx
+++ b/apps/frontend/src/components/Background.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function Background() {
+  return (
+    <div className="fixed inset-0 -z-10 overflow-hidden">
+      <div className="absolute -inset-[30%] bg-gradient-radial from-violet-500 via-blue-500 to-indigo-500 opacity-30 rounded-full animate-[spin_20s_linear_infinite]" />
+      <div className="absolute top-1/4 left-1/3 w-72 h-72 bg-white/20 rounded-full blur-3xl animate-float" />
+      <div className="absolute bottom-1/3 right-1/4 w-96 h-96 bg-indigo-300/20 rounded-full blur-3xl animate-float-reverse" />
+      <div className="absolute top-3/4 left-1/4 w-52 h-52 bg-violet-400/20 rounded-full blur-2xl animate-float" />
+    </div>
+  );
+}

--- a/apps/frontend/tailwind.config.js
+++ b/apps/frontend/tailwind.config.js
@@ -21,6 +21,20 @@ module.exports = {
         '128': '32rem',
         '144': '36rem',
       },
+      keyframes: {
+        float: {
+          '0%, 100%': { transform: 'translateY(0)' },
+          '50%': { transform: 'translateY(-20px)' },
+        },
+        'float-reverse': {
+          '0%, 100%': { transform: 'translateY(0)' },
+          '50%': { transform: 'translateY(20px)' },
+        },
+      },
+      animation: {
+        float: 'float 6s ease-in-out infinite',
+        'float-reverse': 'float-reverse 6s ease-in-out infinite',
+      },
     },
   },
 }


### PR DESCRIPTION
## Summary
- add global `Background` component with radial gradient and floating shapes
- plug the background into `AppLayout`
- define Tailwind animations for floating elements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68765cbe548483228ac405d1508031d0