### PR TITLE
Remove gray section backgrounds

### DIFF
--- a/apps/frontend/src/components/Features.tsx
+++ b/apps/frontend/src/components/Features.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 export default function Features() {
   const { t } = useTranslation();
   return (
-    <section className="bg-gray-50 py-16" id="features" data-aos="fade-up">
+    <section className="py-16" id="features" data-aos="fade-up">
       <h2 className="text-2xl font-bold text-center mb-8">{t('features.title')}</h2>
       <div className="max-w-5xl mx-auto px-4">
         <div className="grid md:grid-cols-3 gap-8">

--- a/apps/frontend/src/components/Hero.tsx
+++ b/apps/frontend/src/components/Hero.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 export default function Hero() {
   const { t } = useTranslation();
   return (
-    <section className="text-center py-20 bg-gray-50" data-aos="fade-up">
+    <section className="text-center py-20" data-aos="fade-up">
       <img src="/illustration.svg" alt={t('hero.imageAlt')} className="mx-auto mb-8 max-w-md" />
       <h1 className="text-3xl sm:text-5xl font-bold mb-6 max-w-4xl mx-auto">{t('hero.title')}</h1>
       <p className="max-w-3xl mx-auto mb-8 text-lg text-gray-600">{t('hero.subtitle')}</p>

--- a/apps/frontend/src/components/Pricing.tsx
+++ b/apps/frontend/src/components/Pricing.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 export default function Pricing() {
   const { t } = useTranslation();
   return (
-    <section className="bg-gray-50 py-16" id="pricing" data-aos="fade-up">
+    <section className="py-16" id="pricing" data-aos="fade-up">
       <h2 className="text-2xl font-bold text-center mb-8">{t('pricing.title')}</h2>
       <div className="max-w-6xl mx-auto grid md:grid-cols-3 gap-6 px-4">
         <div className="border rounded-lg p-6 text-center flex flex-col">

--- a/apps/frontend/src/components/Why.tsx
+++ b/apps/frontend/src/components/Why.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 export default function Why() {
   const { t } = useTranslation();
   return (
-    <section className="bg-gray-50 py-16" data-aos="fade-up">
+    <section className="py-16" data-aos="fade-up">
       <h2 className="text-2xl font-bold text-center mb-8">{t('why.title')}</h2>
       <div className="max-w-5xl mx-auto grid md:grid-cols-4 gap-8 px-4 text-center">
         <div>


### PR DESCRIPTION
## Summary
- remove `bg-gray-50` from hero section
- ensure Features, Why and Pricing sections match with transparent background

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68765f6e65d08322bc87a72c3200af0f