### PR TITLE
Swap signup buttons for links

### DIFF
--- a/apps/frontend/src/components/Hero.tsx
+++ b/apps/frontend/src/components/Hero.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Link from 'next/link';
 import { useTranslation } from 'react-i18next';
 
 export default function Hero() {
@@ -19,9 +20,9 @@ export default function Hero() {
             <button className="rounded-full bg-blue-600 hover:bg-blue-700 px-6 py-3 text-white text-lg md:text-xl">
               {t('hero.ctaPrimary')}
             </button>
-            <button className="rounded-full border border-white px-6 py-3 text-white text-lg md:text-xl">
+            <Link href="/signup" className="rounded-full border border-white px-6 py-3 text-white text-lg md:text-xl">
               {t('hero.ctaSecondary')}
-            </button>
+            </Link>
           </div>
         </div>
         <img

--- a/apps/frontend/src/components/Navbar.tsx
+++ b/apps/frontend/src/components/Navbar.tsx
@@ -1,4 +1,5 @@
 import { BookOpenIcon, Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
+import Link from 'next/link';
 import { useTranslation } from 'react-i18next';
 import { useEffect, useState, type ChangeEvent } from 'react';
 
@@ -54,9 +55,9 @@ export default function Navbar() {
           <button className="rounded-full border border-blue-600 px-4 py-2">
             {t('nav.login')}
           </button>
-          <button className="rounded-full bg-blue-600 hover:bg-blue-700 px-4 py-2 text-white">
+          <Link href="/signup" className="rounded-full bg-blue-600 hover:bg-blue-700 px-4 py-2 text-white">
             {t('nav.signup')}
-          </button>
+          </Link>
           <select
             value={i18n.language}
             onChange={changeLanguage}
@@ -101,12 +102,13 @@ export default function Navbar() {
             </button>
           </li>
           <li>
-            <button
+            <Link
+              href="/signup"
               onClick={handleItemClick}
               className="w-full text-start rounded-full bg-blue-600 hover:bg-blue-700 px-4 py-2 text-white"
             >
               {t('nav.signup')}
-            </button>
+            </Link>
           </li>
           <li>
             <select


### PR DESCRIPTION
## Summary
- use `Link` for sign-up actions in Navbar and Hero

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687ce5feab58832296dada917bbc71a0