### PR TITLE
Localize signup page

### DIFF
--- a/apps/frontend/src/locales/ar/translation.json
+++ b/apps/frontend/src/locales/ar/translation.json
@@ -133,7 +133,13 @@
     "email": "البريد الإلكتروني",
     "password": "كلمة المرور",
     "register": "إنشاء حساب",
-    "login": "تسجيل الدخول"
+    "login": "تسجيل الدخول",
+    "createAccountTitle": "أنشئ حسابك",
+    "signUpAs": "سجّل كـ{{role}}",
+    "institutionName": "اسم المؤسسة",
+    "name": "الاسم",
+    "back": "رجوع",
+    "alreadyAccount": "لديك حساب بالفعل؟"
   },
   "footer": {
     "legal": {

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -133,7 +133,13 @@
     "email": "Email",
     "password": "Password",
     "register": "Create an account",
-    "login": "Log in"
+    "login": "Log in",
+    "createAccountTitle": "Create your account",
+    "signUpAs": "Sign up as {{role}}",
+    "institutionName": "Institution name",
+    "name": "Name",
+    "back": "Back",
+    "alreadyAccount": "Already have an account?"
   },
   "footer": {
     "legal": {

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -133,7 +133,13 @@
     "email": "Email",
     "password": "Mot de passe",
     "register": "Créer un compte",
-    "login": "Se connecter"
+    "login": "Se connecter",
+    "createAccountTitle": "Créez votre compte",
+    "signUpAs": "Inscrivez-vous en tant que {{role}}",
+    "institutionName": "Nom de l'établissement",
+    "name": "Nom",
+    "back": "Retour",
+    "alreadyAccount": "Vous avez déjà un compte ?"
   },
   "footer": {
     "legal": {

--- a/apps/frontend/src/pages/signup.tsx
+++ b/apps/frontend/src/pages/signup.tsx
@@ -2,21 +2,23 @@ import { useState } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import AppLayout from '../components/AppLayout';
+import { useTranslation } from 'react-i18next';
 
 export default function Signup() {
   const [role, setRole] = useState<'institution' | 'learner' | null>(null);
   const [step, setStep] = useState(1);
+  const { t } = useTranslation();
 
   return (
     <AppLayout>
       <div className="min-h-screen flex items-center justify-center py-12 px-4">
         <Head>
-          <title>Sign Up</title>
+          <title>{t('auth.createAccountTitle')}</title>
         </Head>
         <div className="max-w-md w-full space-y-6 bg-black/40 p-8 rounded-lg backdrop-blur-md">
           {step === 1 && (
             <div className="space-y-6 text-center">
-              <h1 className="text-3xl font-bold">Create your account</h1>
+              <h1 className="text-3xl font-bold">{t('auth.createAccountTitle')}</h1>
               <div className="flex justify-center space-x-4 rtl:space-x-reverse">
                 <button
                   className="bg-indigo-600 hover:bg-indigo-700 px-4 py-2 rounded"
@@ -25,7 +27,7 @@ export default function Signup() {
                     setStep(2);
                   }}
                 >
-                  Institution
+                  {t('auth.institution')}
                 </button>
                 <button
                   className="bg-indigo-600 hover:bg-indigo-700 px-4 py-2 rounded"
@@ -34,13 +36,13 @@ export default function Signup() {
                     setStep(2);
                   }}
                 >
-                  Learner
+                  {t('auth.learner')}
                 </button>
               </div>
               <p className="text-sm">
-                Already have an account?{' '}
+                {t('auth.alreadyAccount')} {' '}
                 <Link href="/login" className="underline text-indigo-300">
-                  Log in
+                  {t('auth.login')}
                 </Link>
               </p>
             </div>
@@ -49,47 +51,49 @@ export default function Signup() {
           {step === 2 && role && (
             <form className="space-y-4">
               <h1 className="text-2xl font-semibold text-center">
-                Sign up as {role === 'institution' ? 'Institution' : 'Learner'}
+                {t('auth.signUpAs', {
+                  role: role === 'institution' ? t('auth.institution') : t('auth.learner'),
+                })}
               </h1>
               {role === 'institution' && (
                 <input
                   type="text"
-                  placeholder="Institution name"
+                  placeholder={t('auth.institutionName')}
                   className="w-full px-3 py-2 rounded text-gray-900"
                 />
               )}
               <input
                 type="text"
-                placeholder="Name"
+                placeholder={t('auth.name')}
                 className="w-full px-3 py-2 rounded text-gray-900"
               />
               <input
                 type="email"
-                placeholder="Email"
+                placeholder={t('auth.email')}
                 className="w-full px-3 py-2 rounded text-gray-900"
               />
               <input
                 type="password"
-                placeholder="Password"
+                placeholder={t('auth.password')}
                 className="w-full px-3 py-2 rounded text-gray-900"
               />
               <button
                 type="submit"
                 className="w-full bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded"
               >
-                Create account
+                {t('auth.register')}
               </button>
               <button
                 type="button"
                 className="w-full text-sm underline text-indigo-200"
                 onClick={() => setStep(1)}
               >
-                Back
+                {t('auth.back')}
               </button>
               <p className="text-sm text-center">
-                Already have an account?{' '}
+                {t('auth.alreadyAccount')} {' '}
                 <Link href="/login" className="underline text-indigo-300">
-                  Log in
+                  {t('auth.login')}
                 </Link>
               </p>
             </form>


### PR DESCRIPTION
## Summary
- add translations for signup form fields in all locales
- use translation strings on the signup page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ce7cec46483228e467c8340fdcdc6