### PR TITLE
Fix language persistence

### DIFF
--- a/apps/frontend/src/i18n.ts
+++ b/apps/frontend/src/i18n.ts
@@ -12,11 +12,21 @@ i18n
       fr: { translation: fr },
       ar: { translation: ar },
     },
-    lng: 'fr',
+    lng:
+      typeof window !== 'undefined'
+        ? localStorage.getItem('lang') || 'fr'
+        : 'fr',
     fallbackLng: 'fr',
     interpolation: {
       escapeValue: false,
     },
   });
+
+// Persist language changes in the browser
+if (typeof window !== 'undefined') {
+  i18n.on('languageChanged', (lng) => {
+    localStorage.setItem('lang', lng);
+  });
+}
 
 export default i18n;


### PR DESCRIPTION
## Summary
- remember selected language in `localStorage`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ce9605e5c83229eb7d55067a1e634