### PR TITLE
Implement Supabase signup

### DIFF
--- a/apps/frontend/src/locales/ar/signup.json
+++ b/apps/frontend/src/locales/ar/signup.json
@@ -12,6 +12,7 @@
     "institutionName": "اسم المؤسسة",
     "name": "الاسم",
     "back": "رجوع",
-    "alreadyAccount": "لديك حساب بالفعل؟"
+    "alreadyAccount": "لديك حساب بالفعل؟",
+    "signupSuccess": "تحقق من بريدك الإلكتروني لتأكيد حسابك."
   }
 }

--- a/apps/frontend/src/locales/en/signup.json
+++ b/apps/frontend/src/locales/en/signup.json
@@ -12,6 +12,7 @@
     "institutionName": "Institution name",
     "name": "Name",
     "back": "Back",
-    "alreadyAccount": "Already have an account?"
+    "alreadyAccount": "Already have an account?",
+    "signupSuccess": "Check your email to confirm your account."
   }
 }

--- a/apps/frontend/src/locales/fr/signup.json
+++ b/apps/frontend/src/locales/fr/signup.json
@@ -12,6 +12,7 @@
     "institutionName": "Nom de l'établissement",
     "name": "Nom",
     "back": "Retour",
-    "alreadyAccount": "Vous avez déjà un compte ?"
+    "alreadyAccount": "Vous avez déjà un compte ?",
+    "signupSuccess": "Vérifiez votre e-mail pour confirmer votre compte."
   }
 }

--- a/apps/frontend/src/pages/signup.tsx
+++ b/apps/frontend/src/pages/signup.tsx
@@ -1,13 +1,40 @@
-import { useState } from 'react';
+import { useState, type FormEvent } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import AppLayout from '../components/AppLayout';
 import { useTranslation } from 'react-i18next';
+import { supabase } from '../utils/supabaseClient';
 
 export default function Signup() {
   const [role, setRole] = useState<'institution' | 'learner' | null>(null);
   const [step, setStep] = useState(1);
+  const [institutionName, setInstitutionName] = useState('');
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
   const { t } = useTranslation('signup');
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setMessage('');
+    const { error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: {
+        data: {
+          role,
+          name,
+          institutionName: role === 'institution' ? institutionName : undefined,
+        },
+      },
+    });
+    if (error) {
+      setMessage(error.message);
+    } else {
+      setMessage(t('auth.signupSuccess'));
+    }
+  };
 
   return (
     <AppLayout>
@@ -49,7 +76,7 @@ export default function Signup() {
           )}
 
           {step === 2 && role && (
-            <form className="space-y-4">
+            <form className="space-y-4" onSubmit={handleSubmit}>
               <h1 className="text-2xl font-semibold text-center">
                 {t('auth.signUpAs', {
                   role: role === 'institution' ? t('auth.institution') : t('auth.learner'),
@@ -58,22 +85,30 @@ export default function Signup() {
               {role === 'institution' && (
                 <input
                   type="text"
+                  value={institutionName}
+                  onChange={(e) => setInstitutionName(e.target.value)}
                   placeholder={t('auth.institutionName')}
                   className="w-full px-3 py-2 rounded text-gray-900"
                 />
               )}
               <input
                 type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
                 placeholder={t('auth.name')}
                 className="w-full px-3 py-2 rounded text-gray-900"
               />
               <input
                 type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
                 placeholder={t('auth.email')}
                 className="w-full px-3 py-2 rounded text-gray-900"
               />
               <input
                 type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
                 placeholder={t('auth.password')}
                 className="w-full px-3 py-2 rounded text-gray-900"
               />
@@ -90,6 +125,9 @@ export default function Signup() {
               >
                 {t('auth.back')}
               </button>
+              {message && (
+                <p className="text-center text-sm">{message}</p>
+              )}
               <p className="text-sm text-center">
                 {t('auth.alreadyAccount')} {' '}
                 <Link href="/login" className="underline text-indigo-300">

--- a/apps/frontend/src/utils/supabaseClient.ts
+++ b/apps/frontend/src/utils/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- add Supabase client helper
- implement registration form using Supabase
- display signup confirmation message
- add translation key for signup success in all languages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ced3a02e88322bac54023aa9d23c6