### PR TITLE
Align signup background with landing

### DIFF
--- a/apps/frontend/src/pages/signup.tsx
+++ b/apps/frontend/src/pages/signup.tsx
@@ -1,7 +1,6 @@
 import { useState, type FormEvent } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
-import AppLayout from '../components/AppLayout';
 import { useTranslation } from 'react-i18next';
 import { supabase } from '../utils/supabaseClient';
 import { FiHome, FiUser, FiBook, FiEye, FiEyeOff } from 'react-icons/fi';
@@ -54,8 +53,7 @@ export default function Signup() {
   );
 
   return (
-    <AppLayout>
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-indigo-900 to-black text-gray-100">
+    <div className="min-h-screen flex items-center justify-center text-gray-100">
         <Head>
           <title>{t('auth.createAccountTitle')}</title>
         </Head>
@@ -184,6 +182,6 @@ export default function Signup() {
 
         </div>
       </div>
-    </AppLayout>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove nested `AppLayout` on signup page
- inherit landing background instead of using a custom gradient

## Testing
- `npm --prefix apps/frontend run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cf479ca1c8322a8f880513afd0681