### PR TITLE
Fix missing signup translations

### DIFF
--- a/apps/frontend/src/locales/ar/signup.json
+++ b/apps/frontend/src/locales/ar/signup.json
@@ -13,6 +13,10 @@
     "name": "الاسم",
     "back": "رجوع",
     "alreadyAccount": "لديك حساب بالفعل؟",
-    "signupSuccess": "تحقق من بريدك الإلكتروني لتأكيد حسابك."
+    "signupSuccess": "تحقق من بريدك الإلكتروني لتأكيد حسابك.",
+    "chooseRoleHint": "هل أنت مؤسسة/شركة أم متعلم؟",
+    "checkEmailTitle": "تحقق من بريدك الإلكتروني",
+    "checkEmailSubtitle": "لقد أرسلنا رابط تأكيد إلى بريدك الإلكتروني.",
+    "loginHref": "/login"
   }
 }

--- a/apps/frontend/src/locales/en/signup.json
+++ b/apps/frontend/src/locales/en/signup.json
@@ -13,6 +13,10 @@
     "name": "Name",
     "back": "Back",
     "alreadyAccount": "Already have an account?",
-    "signupSuccess": "Check your email to confirm your account."
+    "signupSuccess": "Check your email to confirm your account.",
+    "chooseRoleHint": "Are you an institution/company or a learner?",
+    "checkEmailTitle": "Check your email",
+    "checkEmailSubtitle": "We sent you a confirmation link to activate your account.",
+    "loginHref": "/login"
   }
 }

--- a/apps/frontend/src/locales/fr/signup.json
+++ b/apps/frontend/src/locales/fr/signup.json
@@ -13,6 +13,10 @@
     "name": "Nom",
     "back": "Retour",
     "alreadyAccount": "Vous avez déjà un compte ?",
-    "signupSuccess": "Vérifiez votre e-mail pour confirmer votre compte."
+    "signupSuccess": "Vérifiez votre e-mail pour confirmer votre compte.",
+    "chooseRoleHint": "Êtes-vous un établissement/entreprise ou un apprenant ?",
+    "checkEmailTitle": "Vérifiez votre e-mail",
+    "checkEmailSubtitle": "Nous vous avons envoyé un lien pour confirmer votre compte.",
+    "loginHref": "/login"
   }
 }


### PR DESCRIPTION
## Summary
- add missing keys to all signup translation files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687cfb6f1aac8322b3dcad990a64a881