### PR TITLE
Move auth pages to auth/ folder

### DIFF
--- a/apps/frontend/src/components/Hero.tsx
+++ b/apps/frontend/src/components/Hero.tsx
@@ -20,7 +20,7 @@ export default function Hero() {
             <button className="rounded-full bg-blue-600 hover:bg-blue-700 px-6 py-3 text-white text-lg md:text-xl">
               {t('hero.ctaPrimary')}
             </button>
-            <Link href="/signup" className="rounded-full border border-white px-6 py-3 text-white text-lg md:text-xl">
+            <Link href="/auth/signup" className="rounded-full border border-white px-6 py-3 text-white text-lg md:text-xl">
               {t('hero.ctaSecondary')}
             </Link>
           </div>

--- a/apps/frontend/src/components/Navbar.tsx
+++ b/apps/frontend/src/components/Navbar.tsx
@@ -55,7 +55,7 @@ export default function Navbar() {
           <button className="rounded-full border border-blue-600 px-4 py-2">
             {t('nav.login')}
           </button>
-          <Link href="/signup" className="rounded-full bg-blue-600 hover:bg-blue-700 px-4 py-2 text-white">
+          <Link href="/auth/signup" className="rounded-full bg-blue-600 hover:bg-blue-700 px-4 py-2 text-white">
             {t('nav.signup')}
           </Link>
           <select
@@ -103,7 +103,7 @@ export default function Navbar() {
           </li>
           <li>
             <Link
-              href="/signup"
+              href="/auth/signup"
               onClick={handleItemClick}
               className="w-full text-start rounded-full bg-blue-600 hover:bg-blue-700 px-4 py-2 text-white"
             >

--- a/apps/frontend/src/locales/ar/signup.json
+++ b/apps/frontend/src/locales/ar/signup.json
@@ -20,6 +20,6 @@
     "chooseRoleHint": "هل أنت مؤسسة/شركة أم متعلم؟",
     "checkEmailTitle": "تحقق من بريدك الإلكتروني",
     "checkEmailSubtitle": "لقد أرسلنا رابط تأكيد إلى بريدك الإلكتروني.",
-    "loginHref": "/login"
+    "loginHref": "/auth/login"
   }
 }

--- a/apps/frontend/src/locales/en/signup.json
+++ b/apps/frontend/src/locales/en/signup.json
@@ -20,6 +20,6 @@
     "chooseRoleHint": "Are you an institution/company or a learner?",
     "checkEmailTitle": "Check your email",
     "checkEmailSubtitle": "We sent you a confirmation link to activate your account.",
-    "loginHref": "/login"
+    "loginHref": "/auth/login"
   }
 }

--- a/apps/frontend/src/locales/fr/signup.json
+++ b/apps/frontend/src/locales/fr/signup.json
@@ -20,6 +20,6 @@
     "chooseRoleHint": "Êtes-vous un établissement/entreprise ou un apprenant ?",
     "checkEmailTitle": "Vérifiez votre e-mail",
     "checkEmailSubtitle": "Nous vous avons envoyé un lien pour confirmer votre compte.",
-    "loginHref": "/login"
+    "loginHref": "/auth/login"
   }
 }

--- a/apps/frontend/src/pages/auth/login.tsx
+++ b/apps/frontend/src/pages/auth/login.tsx
@@ -1,0 +1,92 @@
+import { useState, type FormEvent } from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+import AppLayout from '../../components/AppLayout';
+import { useTranslation } from 'react-i18next';
+import { supabase } from '../../utils/supabaseClient';
+import { FiEye, FiEyeOff } from 'react-icons/fi';
+
+export default function Login() {
+  const { t } = useTranslation('signup');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [showPwd, setShowPwd] = useState(false);
+  const [errorMsg, setErrorMsg] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setErrorMsg('');
+    setLoading(true);
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    setLoading(false);
+    if (error) {
+      setErrorMsg(error.message);
+      return;
+    }
+    window.location.href = '/';
+  };
+
+  return (
+    <AppLayout>
+      <div className="min-h-screen flex items-center justify-center bg-hero-pattern bg-cover bg-center text-gray-100">
+        <Head>
+          <title>{t('auth.login')}</title>
+        </Head>
+
+        <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-5 bg-black/50 backdrop-blur-md p-8 rounded-xl shadow-xl">
+          <h1 className="text-3xl font-bold text-center">{t('auth.login')}</h1>
+          <div>
+            <label htmlFor="email" className="block mb-1 text-sm">{t('auth.email')}</label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="w-full px-4 py-2 rounded-lg bg-gray-800 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            />
+          </div>
+          <div>
+            <label htmlFor="password" className="block mb-1 text-sm">{t('auth.password')}</label>
+            <div className="relative">
+              <input
+                id="password"
+                name="password"
+                type={showPwd ? 'text' : 'password'}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                className="w-full px-4 py-2 rounded-lg bg-gray-800 pr-10 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPwd(!showPwd)}
+                className="absolute inset-y-0 right-3 flex items-center text-gray-400 hover:text-gray-200"
+                tabIndex={-1}
+              >
+                {showPwd ? <FiEyeOff /> : <FiEye />}
+              </button>
+            </div>
+          </div>
+          {errorMsg && <p className="text-sm text-center text-red-400">{errorMsg}</p>}
+          <button
+            type="submit"
+            disabled={loading}
+            className={`w-full flex justify-center items-center space-x-2 py-3 rounded-lg text-white ${loading ? 'bg-indigo-400 cursor-not-allowed' : 'bg-indigo-600 hover:bg-indigo-700'}`}
+          >
+            {loading && <span className="loader-border loader-border-white animate-spin rounded-full w-5 h-5" />}
+            <span>{t('auth.login')}</span>
+          </button>
+          <p className="text-sm text-center">
+            <Link href="/auth/signup" className="underline text-indigo-300 hover:text-indigo-100">
+              {t('auth.register')}
+            </Link>
+          </p>
+        </form>
+      </div>
+    </AppLayout>
+  );
+}

--- a/apps/frontend/src/pages/auth/signup.tsx
+++ b/apps/frontend/src/pages/auth/signup.tsx
@@ -1,9 +1,9 @@
 import { useState, type FormEvent } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
-import AppLayout from '../components/AppLayout';
+import AppLayout from '../../components/AppLayout';
 import { useTranslation } from 'react-i18next';
-import { supabase } from '../utils/supabaseClient';
+import { supabase } from '../../utils/supabaseClient';
 import { FiHome, FiBook, FiEye, FiEyeOff } from 'react-icons/fi';
 
 export default function Signup() {
@@ -117,7 +117,7 @@ export default function Signup() {
               </div>
               <p className="text-sm">
                 {t('auth.alreadyAccount')}{' '}
-                <Link href="/login" className="underline text-indigo-300 hover:text-indigo-100">
+                <Link href="/auth/login" className="underline text-indigo-300 hover:text-indigo-100">
                   {t('auth.login')}
                 </Link>
               </p>
@@ -243,7 +243,7 @@ export default function Signup() {
                 >
                   ← {t('auth.back')}
                 </button>
-                <Link href="/login" className="underline text-indigo-300 hover:text-indigo-100">
+                <Link href="/auth/login" className="underline text-indigo-300 hover:text-indigo-100">
                   {t('auth.alreadyAccount')}
                 </Link>
               </div>


### PR DESCRIPTION
## Summary
- move signup page to `/auth` directory
- create a new `/auth/login` page
- update links to point to `/auth/signup`
- adjust translations to reference new login path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d167d1cfc8322ac0cd888d9afa0d0