### PR TITLE
Fix signup link routing

### DIFF
--- a/apps/frontend/src/components/Navbar.tsx
+++ b/apps/frontend/src/components/Navbar.tsx
@@ -58,7 +58,7 @@ export default function Navbar() {
               {t('nav.login')}
             </button>
           </Link>
-          <Link href="/signup" className="rounded-full bg-blue-600 hover:bg-blue-700 px-4 py-2 text-white">
+          <Link href="/auth/signup" className="rounded-full bg-blue-600 hover:bg-blue-700 px-4 py-2 text-white">
             {t('nav.signup')}
           </Link>
           <select

--- a/apps/frontend/src/pages/login.tsx
+++ b/apps/frontend/src/pages/login.tsx
@@ -70,7 +70,7 @@ export default function Login() {
 
           <p className="text-sm text-center">
             {t('auth.noAccount')}{' '}
-            <Link href="/signup" className="underline text-indigo-300 hover:text-indigo-100">
+            <Link href="/auth/signup" className="underline text-indigo-300 hover:text-indigo-100">
               {t('auth.register')}
             </Link>
           </p>


### PR DESCRIPTION
## Summary
- fix the landing page signup button link
- fix login page link to signup form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d19686d24832291ca353de6e5b5a5